### PR TITLE
Update OSMnx_routing.ipynb; add length as weight 

### DIFF
--- a/OSMnx_routing.ipynb
+++ b/OSMnx_routing.ipynb
@@ -331,8 +331,8 @@
     "ax.scatter(library[1], library[0], c='red', s=100)\n",
     "ax.scatter(museum[1], museum[0], c='blue', s=100)\n",
     "\n",
-    "ax.scatter(G.node[closest_node_to_lib]['x'], G.node[closest_node_to_lib]['y'], c='green', s=100)\n",
-    "ax.scatter(G.node[closest_node_to_museum]['x'], G.node[closest_node_to_museum]['y'], c='green', s=100)\n",
+    "ax.scatter(G.nodes[closest_node_to_lib]['x'], G.nodes[closest_node_to_lib]['y'], c='green', s=100)\n",
+    "ax.scatter(G.nodes[closest_node_to_museum]['x'], G.nodes[closest_node_to_museum]['y'], c='green', s=100)\n",
     "\n",
     "plt.show()"
    ]

--- a/OSMnx_routing.ipynb
+++ b/OSMnx_routing.ipynb
@@ -359,7 +359,7 @@
     }
    ],
    "source": [
-    "route = nx.shortest_path(G, closest_node_to_lib, closest_node_to_museum)\n",
+    "route = nx.shortest_path(G, closest_node_to_lib, closest_node_to_museum, weight='length')\n",
     "\n",
     "fig, ax = ox.plot_graph_route(G, route, fig_height=10, fig_width=10, \n",
     "                    show=False, close=False, \n",


### PR DESCRIPTION
Update OSMnx_routing.ipynb; add length as weight for computing shortest path.

If there is almost no differences between using this option or not on a chessboard-like network, it is definitely not the case on a more complex network where, without this option, it will only rely on the number of edges used to go from point A to point B, hence resulting in some surprising routes...